### PR TITLE
bug fix on the boundary indexing

### DIFF
--- a/original/boundary.c
+++ b/original/boundary.c
@@ -43,9 +43,9 @@ void RandomVelocityBoundary(int sx, int sy, int sz,
 	  continue;
 	}
 	// random speed inside absortion zone
-	else if ((iz>=bord && iz<=2*bordLen+nz) &&
-		 (iy>=bord && iy<=2*bordLen+ny) &&
-		 (ix>=bord && ix<=2*bordLen+nx)) {
+	else if ((iz >= bord && iz <= bord + absorb + nz + absorb - 1) &&
+        (iy >= bord && iy <= bord + absorb + ny + absorb - 1) &&
+        (ix >= bord && ix <= bord + absorb + nx + absorb - 1)) {
 	  if (iz>bordLen+nz) {
 	    distz=iz-bordLen-nz;
 	    ivelz=bordLen+nz;


### PR DESCRIPTION
## Off by one error

Na função `RandomVelocityBoundary`, são recebidos os parâmetros `bord`, que é a grossura da borda, e `absorb`, que é a grossura da zona de absorção. Com isso, as variáveis `bordLen`  e `firstIn` são definidas como:
```c
bordLen = bord + absorb - 1;
firstIn = bordLen + 1;
```
Além disso tem-se `nx`, `ny` e `nz` que são as dimensões da região interna e `sx`, `sy` e `sz` que são as dimensões totais do volume.

Assim, cada sessão existe nos ínidices:

- borda: $[0, bord - 1] \cup  [bord + absorb + nx + absorb, sx - 1]$
- zona de absorção: $[bord, bord + absorb - 1] \cup  [bord + absorb + nx, sx - bord - 1]$
- miolo: $[bord + absorb, bord + absorb + nx - 1]$

Com tudo isso em mãos, a função `RandomVelocityBoundary` itera erroneamente sobre a regição de absorção:
```c
// loop

if ((iz >= firstIn && iz <= bordLen+nz) && 
    (iy >= firstIn && iy <= bordLen+ny) &&
    (ix >= firstIn && ix <= bordLen+nx)) {
    continue;	
}
// aqui pelo menos uma das dimensões não está em [bord + absorb, bord + absorb + nx - 1]

else if ((iz >= bord && iz <= 2 * bordLen + nz) &&
	     (iy >= bord && iy <= 2 * bordLen + ny) &&
             (ix >= bord && ix <= 2 * bordLen + nx)
){
    // aqui, todas as dimensões estão no alcance:
   //  [bord, bord + absorb + nx + absorb + bord - 2] (1)
   // e pelo menos uma medida não está em [bord + absorb, bord + absorb + nx - 1] (2)
  
  // o problema é que o alcance marcado por (1), compreende parte da borda, quando ele deveria compreender apenas
  // a zona de absorção e o miolo, isso pois a borda deve ser nula e no caso será, mas apenas em um lado do volume.
}else{
         // aqui só executa quando um  dos ix, iy e iz for < bord ou > nx - 2, ou seja, o último índice do cubo.  
          vpz[i]=0.0;
	  vsv[i]=0.0;
}
```
O bug fix foi só trocar para as dimensões corretas de  $bord \le i \le (bord + absorb + nx + absorb - 1)$.